### PR TITLE
Apply feedback: refine persistence and validation

### DIFF
--- a/backend/execution_workers/app/worker.py
+++ b/backend/execution_workers/app/worker.py
@@ -1,4 +1,5 @@
 from arq import ArqRedis, create_pool
+import uuid
 from langgraph.checkpoint.redis import RedisSaver
 from langchain_core.messages import ToolMessage, SystemMessage
 import structlog
@@ -37,6 +38,7 @@ async def run_tool(
     message = ToolMessage(
         content=str(result), name=tool_name, tool_call_id=tool_call_id
     )
+    message.id = str(uuid.uuid4())
 
     await checkpoint.update_state(
         {"configurable": {"thread_id": thread_id}}, {"messages": [message]}
@@ -56,6 +58,7 @@ async def run_agent_llm(
     group_members = [GroupMemberRead.model_validate(gm) for gm in group_members_dict]
 
     response = await run_agent(messages, group_members, alias)
+    response.id = str(uuid.uuid4())
 
     await checkpoint.update_state(
         {"configurable": {"thread_id": thread_id}}, {"messages": [response]}

--- a/backend/orchestrator_service/app/graph/nodes.py
+++ b/backend/orchestrator_service/app/graph/nodes.py
@@ -1,8 +1,12 @@
+import json
+import uuid
+from redis.asyncio import Redis
 from .state import GraphState
 from shared.app.utils.message_serde import serialize_messages
 from shared.app.db import AsyncSessionLocal
 from shared.app.models.chat import Message
 from sqlalchemy.dialects.postgresql import insert
+from shared.app.core.config import settings
 import structlog
 from shared.app.core.logging import setup_logging
 
@@ -10,10 +14,51 @@ setup_logging()
 logger = structlog.get_logger(__name__)
 
 
+async def _persist_new_messages(state: GraphState, config: dict) -> None:
+    """Persist any new messages and broadcast them over Redis."""
+    last_saved = state.get("last_saved_index", 0)
+    new_messages = state["messages"][last_saved:]
+    if not new_messages:
+        return
+
+    async with AsyncSessionLocal() as session:
+        redis = Redis.from_url(settings.REDIS_URL)
+        try:
+            for msg in new_messages:
+                stmt = (
+                    insert(Message)
+                    .values(
+                        id=getattr(msg, "id", uuid.uuid4()),
+                        group_id=state["group_id"],
+                        turn_id=state["turn_id"],
+                        sender_alias=getattr(msg, "name", "system"),
+                        content=str(msg.content),
+                        meta=msg.dict(),
+                    )
+                    .on_conflict_do_nothing(index_elements=["id"])
+                )
+                await session.execute(stmt)
+                await redis.publish(
+                    f"group:{state['group_id']}",
+                    json.dumps(msg.dict()),
+                )
+            await session.commit()
+        finally:
+            await redis.close()
+
+    await config["checkpoint"].update_state(
+        config,
+        {"last_saved_index": last_saved + len(new_messages)},
+    )
+
+
 async def dispatch_node(state: GraphState, config: dict) -> dict:
-    """Dispatches jobs to execution_workers based on the last message."""
+    """Persist new messages and dispatch jobs based on the last message."""
     arq_pool = config["arq_pool"]
     thread_id = config["configurable"]["thread_id"]
+
+    await _persist_new_messages(state, config)
+
     last_message = state["messages"][-1]
 
     if tool_calls := getattr(last_message, "tool_calls", []):
@@ -44,32 +89,12 @@ async def dispatch_node(state: GraphState, config: dict) -> dict:
 
 
 async def sync_to_postgres_node(state: GraphState, config: dict) -> dict:
-    """Saves the final, complete conversation history to PostgreSQL."""
+    """Persist any remaining messages before finishing the turn."""
     thread_id = config["configurable"]["thread_id"]
     logger.info("sync_to_postgres.start", thread_id=thread_id)
 
     full_state = await config["checkpoint"].get(config)
-    messages_to_save = full_state["messages"]
+    await _persist_new_messages(full_state, config)
 
-    async with AsyncSessionLocal() as session:
-        for msg in messages_to_save:
-            # This is a simplified conversion. A real implementation needs to handle
-            # different message types and serialize them correctly.
-            stmt = (
-                insert(Message)
-                .values(
-                    id=msg.id,
-                    group_id=state["group_id"],
-                    turn_id=state.get(
-                        "turn_id", "legacy_turn"
-                    ),  # Add turn_id to state if needed
-                    sender_alias=getattr(msg, "name", "system"),
-                    content=str(msg.content),
-                    meta=msg.dict(),  # Store the full message object for perfect reconstruction
-                )
-                .on_conflict_do_nothing(index_elements=["id"])
-            )  # Idempotent insert
-            await session.execute(stmt)
-        await session.commit()
     logger.info("sync_to_postgres.complete", thread_id=thread_id)
     return {}

--- a/backend/orchestrator_service/app/graph/state.py
+++ b/backend/orchestrator_service/app/graph/state.py
@@ -26,3 +26,9 @@ class GraphState(TypedDict):
 
     # A counter to prevent infinite loops, a crucial safety mechanism.
     turn_count: int
+
+    # Index of the last message persisted to the database.
+    last_saved_index: int
+
+    # The ID representing this conversation turn.
+    turn_id: str

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -128,7 +128,7 @@ def test_send_message(monkeypatch, client):
     calls = {}
     class FakePool:
         async def enqueue_job(self, *a, **kw):
-            calls['called']=True
+            calls['called']=kw
     override_db = lambda: FakeSessionMaker(session)
     app.dependency_overrides[groups_router.get_db_session] = override_db
     app.dependency_overrides[groups_router.get_current_user] = lambda: user
@@ -137,4 +137,6 @@ def test_send_message(monkeypatch, client):
     resp = client.post(f"/groups/{gid}/messages", json={"content": "hi"})
     assert resp.status_code == 202
     assert calls.get('called')
+    assert 'message_id' in calls['called']
+    assert 'turn_id' in calls['called']
     app.dependency_overrides = {}

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -46,8 +46,10 @@ async def test_start_turn(monkeypatch):
     monkeypatch.setattr(orch_worker.graph_app, 'ainvoke', fake_ainvoke)
     orch_worker._arq_pool = 'pool'
     monkeypatch.setattr(orch_worker, 'AsyncSessionLocal', lambda: DummyAsyncSession())
-    await orch_worker.start_turn({}, 'gid', 'hi', 'uid')
+    await orch_worker.start_turn({}, 'gid', 'hi', 'uid', 'mid', 'tid')
     assert called['input']['messages'][0].content == 'hi'
+    assert called['input']['turn_id'] == 'tid'
+    assert called['input']['last_saved_index'] == 1
     assert called['config']['arq_pool'] == 'pool'
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- persist messages incrementally in Redis and PostgreSQL
- add message IDs and track persistence progress
- simplify group ownership validation
- update workers and tests for new parameters

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError for dependencies)*
- `pip install -q -r requirements.dev.txt` *(fails: network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6856cc00e578832888fd787b085f1b41