### PR TITLE
Add backend tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,29 @@
+import os
+import pytest
+import pytest_asyncio
+
+@pytest.fixture(scope="session", autouse=True)
+def set_test_env():
+    os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///file::memory:?cache=shared")
+    os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+    os.environ.setdefault("SECRET_KEY", "testsecret")
+    os.environ.setdefault("TAVILY_API_KEY", "dummy")
+    os.environ.setdefault("OPENAI_API_KEY", "dummy")
+    os.environ.setdefault("GEMINI_API_KEY", "dummy")
+    os.environ.setdefault("CLAUDE_API_KEY", "dummy")
+    yield
+
+@pytest_asyncio.fixture(scope="session")
+async def engine(set_test_env):
+    from backend.shared.app.db import engine
+    from backend.shared.app.models import base  # ensure models imported
+    async with engine.begin() as conn:
+        await conn.run_sync(base.Base.metadata.create_all)
+    yield engine
+    async with engine.begin() as conn:
+        await conn.run_sync(base.Base.metadata.drop_all)
+
+@pytest.fixture
+def db_session(engine):
+    from backend.shared.app.db import AsyncSessionLocal
+    return AsyncSessionLocal

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -1,0 +1,53 @@
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "backend"))
+sys.path.insert(0, str(ROOT / "backend" / "api_gateway"))
+
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///file::memory:?cache=shared")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+os.environ.setdefault("SECRET_KEY", "testsecret")
+os.environ.setdefault("TAVILY_API_KEY", "dummy")
+
+import uuid
+import pytest
+from backend.api_gateway.app.api.routers import auth, groups
+from backend.shared.app.schemas.auth import UserCreate
+from backend.shared.app.schemas.groups import GroupCreate, AgentConfigCreate
+from backend.shared.app.models.chat import User
+from backend.api_gateway.app.core.security import get_password_hash
+
+@pytest.mark.asyncio
+async def test_register_and_login(db_session):
+    user_in = UserCreate(email="u@example.com", password="pw")
+    await auth.register_user(user_in, db=db_session)
+    form = type("F", (), {"username": "u@example.com", "password": "pw"})()
+    token = await auth.login_for_access_token(form, db=db_session)
+    assert token["access_token"]
+
+@pytest.mark.asyncio
+async def test_create_group_and_send_message(db_session, monkeypatch):
+    # create user
+    async with db_session() as session:
+        user = User(email="owner@example.com", hashed_password=get_password_hash("pw"))
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+    # override arq pool
+    class FakeArq:
+        def __init__(self):
+            self.jobs=[]
+        async def enqueue_job(self,*a,**k):
+            self.jobs.append((a,k))
+    fake_arq = FakeArq()
+    monkeypatch.setattr("backend.api_gateway.app.api.routers.groups.ArqRedis", object)
+    monkeypatch.setattr("backend.api_gateway.app.api.routers.groups.get_arq_pool", lambda: fake_arq)
+    group_data = GroupCreate(name="g", members=[AgentConfigCreate(alias="A", role_prompt="r")])
+    group = await groups.create_group(group_data, db=db_session, current_user=user)
+    assert group.id
+    # send message
+    msg = await groups.send_message(group.id, message_in=type("M", (), {"content":"hi"})(), db=db_session, arq_pool=fake_arq, current_user=user)
+    assert msg.content == "hi"
+    assert fake_arq.jobs

--- a/tests/test_dispatcher_and_workers.py
+++ b/tests/test_dispatcher_and_workers.py
@@ -1,0 +1,93 @@
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "backend"))
+
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///file::memory:?cache=shared")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+os.environ.setdefault("SECRET_KEY", "testsecret")
+os.environ.setdefault("TAVILY_API_KEY", "dummy")
+
+import uuid
+import pytest
+from langchain_core.messages import AIMessage, ToolMessage, HumanMessage, SystemMessage
+
+from backend.orchestrator_service.app.graph.nodes import dispatcher_node
+from backend.orchestrator_service.app.graph.state import GraphState
+
+# Patch the langchain tool decorator before importing tools/worker
+import langchain_core.tools as lctools
+
+def dummy_tool_decorator(*args, **kwargs):
+    def wrapper(fn):
+        return fn
+    return wrapper
+
+lctools.tool = dummy_tool_decorator
+
+from backend.execution_workers.app.worker import run_tool, run_agent_llm
+
+class FakeArq:
+    def __init__(self):
+        self.jobs = []
+    async def enqueue_job(self, *args, **kwargs):
+        self.jobs.append((args, kwargs))
+
+@pytest.mark.asyncio
+async def test_dispatcher_node_tools():
+    fake_arq = FakeArq()
+    message = AIMessage(content="", tool_calls=[{"name":"web_search","id":"1","args":{}}])
+    state = GraphState(messages=[message], group_id="g", group_members=[], next_actors=[], turn_count=0, last_saved_index=0, turn_id="t")
+    await dispatcher_node(state, {"configurable": {"arq_pool": fake_arq, "thread_id": "g"}})
+    assert fake_arq.jobs
+    args, kwargs = fake_arq.jobs[0]
+    assert args[0] == "run_tool" and kwargs["tool_name"] == "web_search"
+
+@pytest.mark.asyncio
+async def test_dispatcher_node_agents():
+    fake_arq = FakeArq()
+    msg = AIMessage(content="hi")
+    from backend.shared.app.schemas.groups import GroupMemberRead
+    member = GroupMemberRead(id=uuid.uuid4(), alias="AgentA", system_prompt="", tools=[], provider="openai", model="gpt-4o", temperature=0.1)
+    state = GraphState(messages=[msg], group_id="g", group_members=[member], next_actors=["AgentA"], turn_count=0, last_saved_index=0, turn_id="t")
+    await dispatcher_node(state, {"configurable": {"arq_pool": fake_arq, "thread_id": "g"}})
+    assert fake_arq.jobs
+    job = fake_arq.jobs[0]
+    assert job[0][0] == "run_agent_llm" and job[1]["alias"] == "AgentA"
+
+class DummyTool:
+    async def ainvoke(self, args):
+        return "tool-result"
+
+@pytest.mark.asyncio
+async def test_run_tool_enqueues():
+    fake_arq = FakeArq()
+    ctx = {"redis": fake_arq}
+    from backend.shared.app.agents import tools
+    original = tools.TOOL_REGISTRY
+    tools.TOOL_REGISTRY = {"dummy": DummyTool()}
+    try:
+        await run_tool(ctx, tool_name="dummy", tool_args={}, thread_id="t", tool_call_id="1")
+    finally:
+        tools.TOOL_REGISTRY = original
+    assert fake_arq.jobs
+    job = fake_arq.jobs[0]
+    assert job[0][0] == "update_graph_with_message"
+
+class DummyResponse(SystemMessage):
+    pass
+
+@pytest.mark.asyncio
+async def test_run_agent_llm_enqueues(monkeypatch):
+    fake_arq = FakeArq()
+    ctx = {"redis": fake_arq}
+    async def fake_runner(messages, members, alias):
+        return SystemMessage(content="result", name=alias)
+    monkeypatch.setattr("backend.shared.app.agents.runner.run_agent", fake_runner)
+    messages_dict = [{"type":"constructor","id":"1","kwargs":{"content":"hi","name":"User","lc":1,"id":None},"schema":"langchain_core.messages.human.HumanMessage"}]
+    member = {"id": str(uuid.uuid4()), "alias": "AgentA", "system_prompt": "", "tools": [], "provider": "openai", "model": "gpt-4o", "temperature": 0.1}
+    await run_agent_llm(ctx, alias="AgentA", messages_dict=messages_dict, group_members_dict=[member], thread_id="t")
+    assert fake_arq.jobs
+    assert fake_arq.jobs[0][0][0] == "update_graph_with_message"

--- a/tests/test_message_serde.py
+++ b/tests/test_message_serde.py
@@ -1,0 +1,23 @@
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "backend"))
+
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///file::memory:?cache=shared")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+os.environ.setdefault("SECRET_KEY", "testsecret")
+os.environ.setdefault("TAVILY_API_KEY", "dummy")
+
+import pytest
+from langchain_core.messages import HumanMessage, AIMessage
+from backend.shared.app.utils.message_serde import serialize_messages, deserialize_messages
+
+@pytest.mark.asyncio
+async def test_message_roundtrip():
+    messages = [HumanMessage(content="hi"), AIMessage(content="there")]
+    serialized = serialize_messages(messages)
+    deserialized = deserialize_messages(serialized)
+    assert [m.content for m in deserialized] == ["hi", "there"]
+    assert [type(m) for m in deserialized] == [HumanMessage, AIMessage]

--- a/tests/test_router_logic.py
+++ b/tests/test_router_logic.py
@@ -1,0 +1,61 @@
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "backend"))
+
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///file::memory:?cache=shared")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+os.environ.setdefault("SECRET_KEY", "testsecret")
+os.environ.setdefault("TAVILY_API_KEY", "dummy")
+
+import pytest
+from langchain_core.messages import AIMessage, SystemMessage
+from backend.orchestrator_service.app.graph.router import route_logic
+from backend.orchestrator_service.app.graph.state import GraphState
+
+@pytest.mark.asyncio
+async def test_route_logic_with_mentions():
+    state = GraphState(
+        messages=[AIMessage(content="hello @AgentA")],
+        group_id="g",
+        group_members=[],
+        next_actors=[],
+        turn_count=0,
+        last_saved_index=0,
+        turn_id="t",
+    )
+    update = route_logic(state)
+    assert update["next_actors"] == ["AgentA"]
+    assert update["turn_count"] == 1
+
+@pytest.mark.asyncio
+async def test_route_logic_task_complete():
+    state = GraphState(
+        messages=[AIMessage(content="done TASK_COMPLETE", name="Orchestrator")],
+        group_id="g",
+        group_members=[],
+        next_actors=[],
+        turn_count=5,
+        last_saved_index=0,
+        turn_id="t",
+    )
+    update = route_logic(state)
+    assert update["next_actors"] == []
+    assert update["turn_count"] == 6
+
+@pytest.mark.asyncio
+async def test_route_logic_system_error():
+    state = GraphState(
+        messages=[SystemMessage(content="boom", name="system_error")],
+        group_id="g",
+        group_members=[],
+        next_actors=[],
+        turn_count=2,
+        last_saved_index=0,
+        turn_id="t",
+    )
+    update = route_logic(state)
+    assert update["next_actors"] == ["Orchestrator"]
+    assert update["turn_count"] == 3


### PR DESCRIPTION
## Summary
- add pytest configuration and fixtures
- create tests for API routes, dispatch workers, router logic, and message serialization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68594158e0888328acf8aaba267a2860